### PR TITLE
following a service stop error the LimitNPROC must be reduced

### DIFF
--- a/templates/jira.systemd.j2
+++ b/templates/jira.systemd.j2
@@ -15,7 +15,7 @@ Environment="{{ kv.key }}={{ kv.value }}"
 {% endfor %}
 {% endif %}
 LimitNOFILE=4096
-LimitNPROC=4096
+LimitNPROC=1024
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
following a service stop error " Unable to enable service jira: Failed to enable unit: Refusing to operate on alias name or linked unit file: jira.service" -> the LimitNPROC must be reduced