### PR TITLE
fix handlers to restarted jira service

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,4 +4,3 @@
     name: "jira"
     state: restarted
     daemon_reload: true
-    enabled: true


### PR DESCRIPTION
following a service stop error " Unable to enable service jira: Failed to enable unit: Refusing to operate on alias name or linked unit file: jira.service" -> removed enabled service